### PR TITLE
feat: Align chart for ingress TLS configuration(#33)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -34,8 +34,9 @@ A Helm chart for EDP Gerrit Operator
 | gerrit.imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied for gerrit deployment |
 | gerrit.imagePullSecrets | string | `nil` | Secrets to pull from private Docker registry; |
 | gerrit.ingress.annotations | object | `{}` |  |
+| gerrit.ingress.host | string | `""` | If hosts not defined the will create by pattern "gerrit-[namespace].[global DNS wildcard]" |
 | gerrit.ingress.pathType | string | `"Prefix"` | pathType is only for k8s >= 1.1= |
-| gerrit.ingress.tls | list | `[]` | See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress ingressClassName: nginx |
+| gerrit.ingress.tls | list | `[]` | If hosts not defined the will create by pattern "gerrit-[namespace].[global DNS wildcard]" |
 | gerrit.javaOptions | string | `""` | Values to add to JAVA_OPTIONS |
 | gerrit.name | string | `"gerrit"` | Gerrit name |
 | gerrit.nodeSelector | object | `{}` |  |

--- a/deploy-templates/templates/_helpers.tpl
+++ b/deploy-templates/templates/_helpers.tpl
@@ -104,3 +104,14 @@ Set gerrit.javaOptions
 {{ printf "%s" .Values.gerrit.javaOptions }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define gerrit-operator URL
+*/}}
+{{- define "gerrit.url" -}}
+{{- if .Values.gerrit.basePath -}}
+{{ .Values.global.dnsWildCard }}
+{{- else -}}
+gerrit-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }}
+{{- end }}
+{{- end }}

--- a/deploy-templates/templates/ingress.yaml
+++ b/deploy-templates/templates/ingress.yaml
@@ -20,10 +20,22 @@ spec:
   {{- end }}
 {{- if .Values.gerrit.ingress.tls }}
   tls:
-{{ tpl (toYaml .Values.gerrit.ingress.tls) $ | indent 4 }}
-{{- end }}
+    {{- range .Values.gerrit.ingress.tls }}
+    - hosts:
+        {{- if .hosts }}
+        {{- toYaml .hosts | nindent 8 }}
+        {{- else }}
+        - {{ include "gerrit.url" $ }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{if .Values.gerrit.basePath}}{{ .Values.global.dnsWildCard }}{{else}}gerrit-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }}{{end}}
+    {{- if .Values.gerrit.ingress.host }}
+    - host: {{ .Values.gerrit.ingress.host }}
+    {{- else}}
+    - host: {{ include "gerrit.url" . }}
+    {{- end}}
       http:
         paths:
           - path: {{if .Values.gerrit.basePath}}/{{.Values.gerrit.basePath}}(/|$)(.*){{else}}/{{end}}
@@ -34,7 +46,7 @@ spec:
               {{- if $ingressApiIsStable }}
               service:
                 name: {{ .Values.gerrit.name }}
-                port: 
+                port:
                   number: 8080
               {{- else }}
               serviceName: {{ .Values.gerrit.name }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -80,6 +80,11 @@ gerrit:
     # --  For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # --  See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
+    # -- Defines the base URL for the portal.
+    # -- If hosts not defined the will create by pattern "gerrit-[namespace].[global DNS wildcard]"
+    host: ""
+    # -- Ingress TLS configuration
+    # -- If hosts not defined the will create by pattern "gerrit-[namespace].[global DNS wildcard]"
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
## Description
This pull request introduces several updates and improvements to the Helm chart for the EDP Gerrit Operator. The changes include updates to the README.md, _helpers.tpl, ingress.yaml, and values.yaml files to enhance the functionality and user experience of the Gerrit deployment on Kubernetes. Key modifications involve the introduction of a new way to define the Gerrit URL, updates to the ingress configuration to support dynamic host names based on the namespace or a specified base path, and the addition of comments for better understanding of the ingress TLS configuration.

## Fixes
Enhanced Gerrit URL configuration for flexible ingress definitions.
Improved ingress TLS documentation and configuration options.
Added comments and documentation for clarity and maintenance ease.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The changes were tested by deploying the updated Helm chart in a Kubernetes cluster and verifying that the Gerrit service is accessible via the newly configured ingress rules. Various scenarios were tested including deployments with and without a specified base path, and using default and custom DNS wildcards.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings