### PR TITLE
chore: Bump gerrit image version to 3.7.9 (#39)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -45,7 +45,7 @@ A Helm chart for EDP Gerrit Operator
 | gerrit.resources.requests.memory | string | `"512Mi"` |  |
 | gerrit.storage.size | string | `"1Gi"` | Size for Gerrit data volume |
 | gerrit.tolerations | list | `[]` |  |
-| gerrit.version | string | `"3.6.2"` | Define gerrit docker image tag |
+| gerrit.version | string | `"3.7.9"` | Define gerrit docker image tag |
 | global.admins | list | `["stub_user_one@example.com"]` | Administrators of your tenant |
 | global.developers | list | `["stub_user_one@example.com","stub_user_two@example.com"]` | Developers of your tenant |
 | global.dnsWildCard | string | `nil` | a cluster DNS wildcard name |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -54,7 +54,7 @@ gerrit:
   # -- Define gerrit docker image name
   image: "epamedp/edp-gerrit"
   # -- Define gerrit docker image tag
-  version: "3.6.2"
+  version: "3.7.9"
   # -- If defined, a imagePullPolicy applied for gerrit deployment
   imagePullPolicy: "IfNotPresent"
   # --  Secrets to pull from private Docker registry;


### PR DESCRIPTION
# Pull Request Template

## Description
This PR updates the Docker image for our Gerrit from version 3.6.2  to 3.7.2

Fixes 39

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
The change was tested by deploying the updated Docker image in a development environment and verifying that the Gerrit service operates as expected.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate):
N/A

## Additional context
N/A