### PR TITLE
chore: Update oauth gerrit plugin instead of gerrit version (#39)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -45,7 +45,7 @@ A Helm chart for EDP Gerrit Operator
 | gerrit.resources.requests.memory | string | `"512Mi"` |  |
 | gerrit.storage.size | string | `"1Gi"` | Size for Gerrit data volume |
 | gerrit.tolerations | list | `[]` |  |
-| gerrit.version | string | `"3.7.9"` | Define gerrit docker image tag |
+| gerrit.version | string | `"3.6.2-oauth"` | Define gerrit docker image tag |
 | global.admins | list | `["stub_user_one@example.com"]` | Administrators of your tenant |
 | global.developers | list | `["stub_user_one@example.com","stub_user_two@example.com"]` | Developers of your tenant |
 | global.dnsWildCard | string | `nil` | a cluster DNS wildcard name |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -54,7 +54,7 @@ gerrit:
   # -- Define gerrit docker image name
   image: "epamedp/edp-gerrit"
   # -- Define gerrit docker image tag
-  version: "3.7.9"
+  version: "3.6.2-oauth"
   # -- If defined, a imagePullPolicy applied for gerrit deployment
   imagePullPolicy: "IfNotPresent"
   # --  Secrets to pull from private Docker registry;


### PR DESCRIPTION
We need to support keycloak without /auth

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
