### PR TITLE
feat: add optional SSH host key injection for predictable Gerrit host keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ tags
 .idea/**
 vendor/**
 # # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+
+gerrit-ssh-host-keys/

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -44,6 +44,8 @@ A Helm chart for KubeRocketCI Gerrit Operator
 | gerrit.resources.limits.memory | string | `"2Gi"` |  |
 | gerrit.resources.requests.cpu | string | `"100m"` |  |
 | gerrit.resources.requests.memory | string | `"512Mi"` |  |
+| gerrit.sshHostKeys.enabled | bool | `false` | Flag for enabling SSH host key injection from a pre-created Secret |
+| gerrit.sshHostKeys.secret | string | `"gerrit-ssh-host-keys"` | Name of the secret containing the SSH host key pairs |
 | gerrit.sso.enabled | bool | `true` |  |
 | gerrit.sso.keycloakUrl | string | `"https://keycloak.example.com/auth"` | Keycloak URL. |
 | gerrit.sso.kind | string | `"KeycloakRealm"` |  |

--- a/deploy-templates/templates/gerrit_deployment/gerrit_deployment_config_openshift.yaml
+++ b/deploy-templates/templates/gerrit_deployment/gerrit_deployment_config_openshift.yaml
@@ -78,6 +78,15 @@ spec:
           volumeMounts:
             - mountPath: /var/gerrit/review_site
               name: {{ .Values.gerrit.name }}-data
+            {{- if .Values.gerrit.sshHostKeys.enabled }}
+            # Side path: the review_site PVC mount covers etc/, so the keys are
+            # copied into place by the docker-entrypoint-init.d hook below.
+            - name: ssh-host-keys
+              mountPath: /var/gerrit/ssh-host-keys
+              readOnly: true
+            - name: ssh-host-keys-init
+              mountPath: /docker-entrypoint-init.d
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -89,6 +98,15 @@ spec:
         - name: {{ .Values.gerrit.name }}-data
           persistentVolumeClaim:
             claimName: {{ .Values.gerrit.name }}-data
+        {{- if .Values.gerrit.sshHostKeys.enabled }}
+        - name: ssh-host-keys
+          secret:
+            secretName: {{ .Values.gerrit.sshHostKeys.secret }}
+            defaultMode: 0400
+        - name: ssh-host-keys-init
+          configMap:
+            name: {{ .Values.gerrit.name }}-ssh-host-keys-init
+        {{- end }}
       {{- with .Values.gerrit.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy-templates/templates/gerrit_deployment/gerrit_deployment_kubernetes.yaml
+++ b/deploy-templates/templates/gerrit_deployment/gerrit_deployment_kubernetes.yaml
@@ -33,6 +33,15 @@ spec:
           secret:
             secretName: {{ .Values.gerrit.caCerts.secret }}
       {{- end }}
+      {{- if .Values.gerrit.sshHostKeys.enabled }}
+        - name: ssh-host-keys
+          secret:
+            secretName: {{ .Values.gerrit.sshHostKeys.secret }}
+            defaultMode: 0400
+        - name: ssh-host-keys-init
+          configMap:
+            name: {{ .Values.gerrit.name }}-ssh-host-keys-init
+      {{- end }}
       initContainers:
       {{- if .Values.gerrit.caCerts.enabled }}
         - name: ca-certs
@@ -76,6 +85,15 @@ spec:
             - name: {{ .Values.gerrit.name }}-data
               mountPath: /var/gerrit/review_site/certs
               subPath: certs
+            {{- end }}
+            {{- if .Values.gerrit.sshHostKeys.enabled }}
+            # Side path: the review_site PVC mount covers etc/, so the keys are
+            # copied into place by the docker-entrypoint-init.d hook below.
+            - name: ssh-host-keys
+              mountPath: /var/gerrit/ssh-host-keys
+              readOnly: true
+            - name: ssh-host-keys-init
+              mountPath: /docker-entrypoint-init.d
             {{- end }}
           # The startup probe absorbs the slow first boot (site init + reindex),
           # so readiness needs no fixed initial delay: a warm Gerrit serves in

--- a/deploy-templates/templates/gerrit_deployment/gerrit_ssh_host_keys_init_cm.yaml
+++ b/deploy-templates/templates/gerrit_deployment/gerrit_ssh_host_keys_init_cm.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.gerrit.deploy .Values.gerrit.sshHostKeys.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.gerrit.name }}-ssh-host-keys-init
+  labels:
+    app: {{ .Values.gerrit.name }}
+    {{- include "gerrit-operator.labels" . | nindent 4 }}
+data:
+  ssh-host-keys.sh: |
+    # Sourced as root by gerrit-entrypoint.sh (set -e active) after the
+    # first-time `gerrit init` and before the daemon starts, so the pinned
+    # keys below are what sshd loads. `cp -f` also converges sites whose PVC
+    # already holds randomly generated keys. The later `gerrit init` run never
+    # regenerates host keys that exist.
+    for f in /var/gerrit/ssh-host-keys/ssh_host_*; do
+      key="$(basename "$f")"
+      cp -f "$f" "${GERRIT_SITE}/etc/${key}"
+      chown "${GERRIT_USER}:${GERRIT_USER}" "${GERRIT_SITE}/etc/${key}"
+      case "$key" in
+        *.pub) chmod 644 "${GERRIT_SITE}/etc/${key}" ;;
+        *)     chmod 600 "${GERRIT_SITE}/etc/${key}" ;;
+      esac
+    done
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -116,6 +116,22 @@ gerrit:
     # -- Name of the secret containing additional CA certificates
     secret: secret-name
 
+  # Install pre-generated SSH host keys from a Secret so Gerrit serves predictable
+  # host keys across pod restarts and reinstalls, letting clients (ArgoCD,
+  # codebase-operator) pin them statically instead of running ssh-keyscan.
+  # Intended for test environments only: whoever holds the Secret can impersonate
+  # this Gerrit. The Secret must contain the full key set Gerrit would otherwise
+  # generate (ssh_host_rsa_key, ssh_host_ecdsa_key, ssh_host_ecdsa_384_key,
+  # ssh_host_ecdsa_521_key, ssh_host_ed25519_key), each with its .pub half —
+  # any type left out is generated randomly at init and stays unpinned.
+  # Generate the keys, the Secret manifest and the client known_hosts entries
+  # with scripts/generate-ssh-host-keys.sh.
+  sshHostKeys:
+    # -- Flag for enabling SSH host key injection from a pre-created Secret
+    enabled: false
+    # -- Name of the secret containing the SSH host key pairs
+    secret: gerrit-ssh-host-keys
+
   # -- Values to add to JAVA_OPTIONS
   javaOptions: ""
   # -- Additional environment variables

--- a/scripts/generate-ssh-host-keys.sh
+++ b/scripts/generate-ssh-host-keys.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Generate the full SSH host key set for the gerrit.sshHostKeys chart feature.
+#
+# Produces every key type Gerrit would otherwise generate at init (any type
+# left out would be created randomly and stay unpinned), plus ready-to-apply
+# artifacts built from them:
+#
+#   <out>/ssh_host_*_key[.pub]  the key pairs (Secret content)
+#   <out>/secret.yaml           Kubernetes Secret manifest for the chart
+#   <out>/known_hosts           pinned entries for SSH clients (ArgoCD,
+#                               codebase-operator knownHosts.entries), when
+#                               --host is given
+#
+# The private keys let their holder impersonate this Gerrit: use them in test
+# environments only and keep them out of git. The known_hosts file contains
+# only public halves and is safe to commit.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: generate-ssh-host-keys.sh [options]
+
+Options:
+  -o, --output DIR      Output directory (default: ./gerrit-ssh-host-keys).
+                        Keys are generated only if the directory holds none;
+                        an existing set is reused, so one key set can serve
+                        any number of namespaces/hosts.
+  -s, --secret NAME     Secret name in the manifest (default: gerrit-ssh-host-keys,
+                        the chart's gerrit.sshHostKeys.secret default)
+  -n, --namespace NS    Namespace in the manifest (default: omitted, so the
+                        manifest applies to the current kubectl namespace)
+  -H, --host HOST       Gerrit SSH host, e.g. gerrit.my-namespace; enables
+                        known_hosts generation
+  -p, --port PORT       Gerrit SSH port for known_hosts entries (default: 22;
+                        any other port uses the [host]:port bracket form)
+  -h, --help            Show this help
+
+Examples:
+  # generate the single key set once (e.g. to load into an external secret store)
+  generate-ssh-host-keys.sh -o ~/gerrit-keys
+  # derive pinned known_hosts entries per namespace from the same set;
+  # entries accumulate in one known_hosts file, stale ones are replaced
+  generate-ssh-host-keys.sh -o ~/gerrit-keys -H gerrit.ns-a -p 30022
+  generate-ssh-host-keys.sh -o ~/gerrit-keys -H gerrit.ns-b -p 30022
+EOF
+}
+
+out_dir="./gerrit-ssh-host-keys"
+secret_name="gerrit-ssh-host-keys"
+namespace=""
+host=""
+port="22"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o|--output)    out_dir="$2"; shift 2 ;;
+    -s|--secret)    secret_name="$2"; shift 2 ;;
+    -n|--namespace) namespace="$2"; shift 2 ;;
+    -H|--host)      host="$2"; shift 2 ;;
+    -p|--port)      port="$2"; shift 2 ;;
+    -h|--help)      usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+for tool in ssh-keygen kubectl; do
+  command -v "$tool" >/dev/null || { echo "Error: $tool not found in PATH" >&2; exit 1; }
+done
+
+# An existing key set is never overwritten: the whole point of pinned keys is
+# that they stay stable. Rerunning against an existing directory only derives
+# artifacts (known_hosts for another host, the Secret manifest) from it.
+if ls "$out_dir"/ssh_host_* >/dev/null 2>&1; then
+  echo "Reusing existing host keys in $out_dir (only deriving artifacts)."
+else
+  mkdir -p "$out_dir"
+  # The set Gerrit (Apache MINA sshd) generates on `gerrit init`.
+  echo "Generating host keys in $out_dir ..."
+  ssh-keygen -q -t ed25519        -N "" -C gerrit -f "$out_dir/ssh_host_ed25519_key"
+  ssh-keygen -q -t rsa   -b 4096  -N "" -C gerrit -f "$out_dir/ssh_host_rsa_key"
+  ssh-keygen -q -t ecdsa -b 256   -N "" -C gerrit -f "$out_dir/ssh_host_ecdsa_key"
+  ssh-keygen -q -t ecdsa -b 384   -N "" -C gerrit -f "$out_dir/ssh_host_ecdsa_384_key"
+  ssh-keygen -q -t ecdsa -b 521   -N "" -C gerrit -f "$out_dir/ssh_host_ecdsa_521_key"
+fi
+
+from_files=()
+for f in "$out_dir"/ssh_host_*key "$out_dir"/ssh_host_*key.pub; do
+  from_files+=("--from-file=$f")
+done
+ns_arg=()
+[ -n "$namespace" ] && ns_arg=(--namespace "$namespace")
+# ${arr[@]+...} keeps empty arrays from tripping `set -u` on bash 3.2 (macOS).
+kubectl create secret generic "$secret_name" ${ns_arg[@]+"${ns_arg[@]}"} "${from_files[@]}" \
+  --dry-run=client -o yaml > "$out_dir/secret.yaml"
+
+if [ -n "$host" ]; then
+  if [ "$port" = "22" ]; then
+    host_entry="$host"
+  else
+    host_entry="[$host]:$port"
+  fi
+  # Upsert: keep entries for other hosts so one file accumulates every
+  # namespace, replace any stale entries for this one.
+  touch "$out_dir/known_hosts"
+  grep -vF "$host_entry " "$out_dir/known_hosts" > "$out_dir/known_hosts.tmp" || true
+  for pub in "$out_dir"/ssh_host_*_key.pub; do
+    # Drop the trailing comment so entries are exactly "host type key".
+    read -r key_type key_data _ < "$pub"
+    echo "$host_entry $key_type $key_data" >> "$out_dir/known_hosts.tmp"
+  done
+  mv "$out_dir/known_hosts.tmp" "$out_dir/known_hosts"
+fi
+
+echo
+echo "Fingerprints:"
+for pub in "$out_dir"/ssh_host_*_key.pub; do
+  ssh-keygen -lf "$pub"
+done
+echo
+echo "Wrote:"
+echo "  $out_dir/secret.yaml (apply, then set gerrit.sshHostKeys.enabled=true)"
+if [ -n "$host" ]; then
+  echo "  $out_dir/known_hosts (entries for ArgoCD / codebase-operator knownHosts.entries)"
+else
+  echo "  (no known_hosts written; pass --host/--port to generate pinned client entries)"
+fi


### PR DESCRIPTION


Gerrit generates random SSH host keys at first init, so every test namespace serves different keys and clients (ArgoCD, codebase-operator) must discover them with a fragile kubectl exec + ssh-keyscan at deploy time. With host key verification now mandatory in codebase-operator, that discovery step doubles.

Mount a pre-created Secret of host keys and install it through the image's existing /docker-entrypoint-init.d extension point, so sshd serves known keys and clients can pin them statically:

- gerrit.sshHostKeys values flag, default off: pinned keys are a test-environment trade-off, never a production default; disabled installs render byte-identical manifests
- the hook copies keys before the daemon starts and converges sites whose PVC already holds random keys; gerrit init never regenerates keys that exist, and a failed copy fails the boot loudly
- one key set serves any number of namespaces and ports, since host keys embed neither; only the [host]:port known_hosts prefix differs per environment
- scripts/generate-ssh-host-keys.sh generates the full key set Gerrit would otherwise create (a type left out would be generated randomly and stay unpinned), the Secret manifest, and accumulating known_hosts entries; an existing key directory is reused, never overwritten
- generated key material is git-ignored

Verified on a kind cluster: two namespaces on different NodePorts served identical pinned fingerprints, strict-checking SSH clients verified against the derived known_hosts, and a rogue key was rejected.

